### PR TITLE
Use wit-bindgen with option in sdk macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3718,7 +3721,7 @@ dependencies = [
  "anyhow",
  "wasm-encoder 0.35.0",
  "wasmparser 0.115.0",
- "wit-component",
+ "wit-component 0.16.1",
  "wit-parser",
 ]
 
@@ -3741,6 +3744,27 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
+]
+
+[[package]]
+name = "spin-cron-macro"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "spin-cron-sdk"
+version = "0.1.0"
+dependencies = [
+ "spin-cron-macro",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5731,10 +5755,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38726c54a5d7c03cac28a2a8de1006cfe40397ddf6def3f836189033a413bc08"
+dependencies = [
+ "bitflags 2.4.1",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bf1fddccaff31a1ad57432d8bfb7027a7e552969b6c68d6d8820dcf5c2371f"
+dependencies = [
+ "anyhow",
+ "wit-component 0.17.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7200e565124801e01b7b5ddafc559e1da1b2e1bed5364d669cd1d96fb88722"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component 0.17.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae33920ad8119fe72cf59eb00f127c0b256a236b9de029a1a10397b1f38bdbd"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+ "wit-component 0.17.0",
+]
+
+[[package]]
 name = "wit-component"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65672b7a81f9c7a4420af2ad8d0de608e27b520a6d4b68f29f5146e060a86ee4"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "indexmap 2.1.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.36.2",
+ "wasm-metadata",
+ "wasmparser 0.116.1",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "480cc1a078b305c1b8510f7c455c76cbd008ee49935f3a6c5fd5e937d8d95b1e"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.1.0"
 authors = ["Karthik Ganeshram <karthik.ganeshram@fermyon.com>"]
 edition = "2021"
 
+[workspace]
+members = ["sdk", "sdk/macro"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/cron.wit
+++ b/cron.wit
@@ -1,4 +1,4 @@
-package fermyon:spin-cron@2.0.0
+package fermyon:spin-cron@2.0.0;
 
 interface cron-types {
     record metadata {
@@ -11,10 +11,10 @@ interface cron-types {
 }
 
 world spin-cron {
-    use cron-types.{metadata, error}
-    export handle-cron-event: func(metadata: metadata) -> result<_, error>
+    use cron-types.{metadata, error};
+    export handle-cron-event: func(metadata: metadata) -> result<_, error>;
 }
 
 world spin-cron-sdk {
-    import cron-types
+    import cron-types;
 }

--- a/guest/Cargo.lock
+++ b/guest/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "equivalent"
@@ -51,9 +51,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -151,18 +151,15 @@ dependencies = [
 name = "guest"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "bytes",
- "http",
+ "spin-cron-sdk",
  "spin-sdk",
- "wit-bindgen",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -175,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -203,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "leb128"
@@ -221,9 +218,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "once_cell"
@@ -233,9 +230,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -251,9 +248,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -291,18 +288,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -365,6 +362,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-cron-macro"
+version = "0.1.0"
+source = "git+https://github.com/fermyon/spin-trigger-cron/#d2ad231b0a772e6f1867a98e751e10bfb1d95fcc"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "spin-cron-sdk"
+version = "0.1.0"
+source = "git+https://github.com/fermyon/spin-trigger-cron/#d2ad231b0a772e6f1867a98e751e10bfb1d95fcc"
+dependencies = [
+ "spin-cron-macro",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "spin-macro"
 version = "0.1.0"
 source = "git+https://github.com/fermyon/spin?tag=v2.0.1#1d72f1c4244ecd8f7e0f150836565b18ef897e64"
@@ -374,7 +394,7 @@ dependencies = [
  "http",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -405,9 +425,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,35 +447,35 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-xid"
@@ -480,18 +500,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b09bc5df933a3dabbdb72ae4b6b71be8ae07f58774d5aa41bd20adcd41a235a"
+checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.13"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4a14bbedb07737809c00843d1f2f88ba0b8950c114283e0387e30b1b6ee558"
+checksum = "d835d67708f6374937c550ad8dd1d17c616ae009e3f00d7a0ac9f7825e78c36a"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -499,8 +519,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.38.0",
- "wasmparser 0.118.0",
+ "wasm-encoder 0.38.1",
+ "wasmparser 0.118.1",
 ]
 
 [[package]]
@@ -515,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.118.0"
+version = "0.118.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbb91574de0011ded32b14db12777e7dd5e9ea2f9d7317a1ab51a9495c75924"
+checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
 dependencies = [
  "indexmap",
  "semver",

--- a/guest/Cargo.toml
+++ b/guest/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "guest"
-version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
+version = "0.1.0"
+authors = ["Karthik Ganeshram <karthik.ganeshram@fermyon.com>"]
+edition = "2021"
 rust-version = "1.71"
 
 [lib]
@@ -10,4 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v2.0.1" }
-spin-cron-sdk = { git = "https://github.com/karthik2804/spin-trigger-cron/" }
+spin-cron-sdk = { git = "https://github.com/fermyon/spin-trigger-cron/" }
+
+[workspace]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,4 +11,4 @@ name = "spin_cron_sdk"
 
 [dependencies]
 spin-cron-macro = { path = "macro" }
-wit-bindgen = "0.13.0"
+wit-bindgen = "0.13.1"

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -16,4 +16,4 @@ http = "0.2"
 proc-macro2 = "1"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
-wit-bindgen = "0.13.0"
+wit-bindgen = "0.13.1"

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use quote::quote;
 
-const WIT_PATH: &str = "../..";
+const WIT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../cron.wit");
 
 #[proc_macro_attribute]
 pub fn cron_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -16,32 +16,18 @@ pub fn cron_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 #preamble
             }
             impl self::preamble::Guest for preamble::Cron {
-                fn handle_cron_event(metadata: self::preamble::fermyon::spin_cron::cron_types::Metadata) -> ::std::result::Result<(), self::preamble::fermyon::spin_cron::cron_types::Error> {
-                    match super::#func_name(::std::convert::TryInto::try_into(metadata).expect("cannot convert from Spin Cron payload")) {
+                fn handle_cron_event(metadata: ::spin_cron_sdk::Metadata) -> ::std::result::Result<(), ::spin_cron_sdk::Error> {
+                    match super::#func_name(metadata) {
                         ::std::result::Result::Ok(()) => ::std::result::Result::Ok(()),
                         ::std::result::Result::Err(e) => {
                             eprintln!("{}", e);
-                            ::std::result::Result::Err(self::preamble::fermyon::spin_cron::cron_types::Error::Other(e.to_string()))
+                            ::std::result::Result::Err(::spin_cron_sdk::Error::Other(e.to_string()))
                         },
                     }
                 }
             }
-            impl ::std::convert::From<self::preamble::fermyon::spin_cron::cron_types::Metadata> for ::spin_cron_sdk::Metadata {
-                fn from(metadata: self::preamble::fermyon::spin_cron::cron_types::Metadata) -> Self  {
-                   Self { timestamp: metadata.timestamp}
-                }
-            }
-
-            impl ::std::convert::From<self::preamble::fermyon::spin_cron::cron_types::Error> for ::spin_cron_sdk::Error {
-                fn from(err: self::preamble::fermyon::spin_cron::cron_types::Error) -> Self {
-                    match err {
-                        self::preamble::fermyon::spin_cron::cron_types::Error::Other(e) => Self::Other(e)
-                    }
-                }
-            }
         }
-    )
-        .into()
+    ).into()
 }
 
 fn preamble() -> proc_macro2::TokenStream {
@@ -54,6 +40,9 @@ fn preamble() -> proc_macro2::TokenStream {
             runtime_path: "::spin_cron_sdk::wit_bindgen::rt",
             exports: {
                 world: Cron
+            },
+            with: {
+                "fermyon:spin-cron/cron-types@2.0.0": ::spin_cron_sdk,
             }
         });
         pub struct Cron;


### PR DESCRIPTION
* Use wit-bindgen macro option `with` in SDK to avoid macro conversions.
* Resolve workspace issues.